### PR TITLE
Remove trailing spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
 ] add CodeInfoTools
 ```
 
-> **Note**: A curated collection of tools for the discerning `Core.CodeInfo` connoisseur. 
-> 
+> **Note**: A curated collection of tools for the discerning `Core.CodeInfo` connoisseur.
+>
 > The architecture of this package is based closely on the [Pipe construct in IRTools.jl](https://github.com/FluxML/IRTools.jl/blob/1f3f43be654a41d0db154fd16b31fdf40f30748c/src/ir/ir.jl#L814-L973). Many (if not all) of the same idioms apply.
 
 ## Motivation

--- a/src/CodeInfoTools.jl
+++ b/src/CodeInfoTools.jl
@@ -1,23 +1,23 @@
 module CodeInfoTools
 
-using Core: CodeInfo 
+using Core: CodeInfo
 
-import Base: iterate, 
-             push!, 
-             pushfirst!, 
-             insert!, 
-             delete!, 
-             getindex, 
-             lastindex, 
-             setindex!, 
-             display, 
-             +, 
-             length, 
-             identity, 
-             isempty, 
+import Base: iterate,
+             push!,
+             pushfirst!,
+             insert!,
+             delete!,
+             getindex,
+             lastindex,
+             setindex!,
+             display,
+             +,
+             length,
+             identity,
+             isempty,
              show
 
-import Core.Compiler: AbstractInterpreter, 
+import Core.Compiler: AbstractInterpreter,
                       OptimizationState,
                       OptimizationParams
 
@@ -25,24 +25,24 @@ import Core.Compiler: AbstractInterpreter,
 ##### Exports
 #####
 
-export code_info, 
+export code_info,
        code_inferred,
-       walk, 
-       var, 
-       Variable, 
-       slot, 
-       get_slot, 
-       Statement, 
-       stmt, 
-       Canvas, 
-       Builder, 
-       slot!, 
-       return!, 
-       renumber, 
-       verify, 
-       finish, 
-       unwrap, 
-       lambda, 
+       walk,
+       var,
+       Variable,
+       slot,
+       get_slot,
+       Statement,
+       stmt,
+       Canvas,
+       Builder,
+       slot!,
+       return!,
+       renumber,
+       verify,
+       finish,
+       unwrap,
+       lambda,
        λ
 
 #####
@@ -85,7 +85,7 @@ slot(ind::Int) = Core.SlotNumber(ind)
 
 function get_slot(ci::CodeInfo, s::Symbol)
     ind = findfirst(el -> el == s, ci.slotnames)
-    ind === nothing && return 
+    ind === nothing && return
     return slot(ind)
 end
 
@@ -174,7 +174,7 @@ Properties to keep in mind:
 1. Insertion anywhere is slow.
 2. Pushing to beginning is slow.
 2. Pushing to end is fast.
-3. Deletion is fast. 
+3. Deletion is fast.
 4. Accessing elements is fast.
 5. Setting elements is fast.
 
@@ -289,7 +289,7 @@ function renumber(c::Canvas)
     d = Dict((s[i][1], i) for  i in 1 : length(s))
     ind = first.(s)
     swap = walk(k -> _get(d, k, k), c.code, Val(:catch_jumps))
-    return Canvas(Tuple{Int, Int}[(i, i) for i in 1 : length(s)], 
+    return Canvas(Tuple{Int, Int}[(i, i) for i in 1 : length(s)],
                   getindex(swap, ind), getindex(c.codelocs, ind))
 end
 
@@ -556,7 +556,7 @@ function code_inferred(mi::Core.Compiler.MethodInstance;
     src = Core.Compiler.retrieve_code_info(mi)
     src === nothing && return nothing
     src.inferred && return src
-    Core.Compiler.validate_code_in_debug_mode(result.linfo, 
+    Core.Compiler.validate_code_in_debug_mode(result.linfo,
                                               src, "lowered")
     frame = @static if VERSION < v"1.8.0-DEV.472"
         Core.Compiler.InferenceState(result, src, false, interp)
@@ -581,16 +581,16 @@ function code_inferred(@nospecialize(f), types::Type{T};
                  for mi in Base.method_instances(f, types, world)])
 end
 
-function code_inferred(@nospecialize(f), t::Type...; 
+function code_inferred(@nospecialize(f), t::Type...;
         world = Base.get_world_counter(),
         interp = Core.Compiler.NativeInterpreter(world))
-    return code_inferred(f, Tuple{t...}; 
+    return code_inferred(f, Tuple{t...};
                          world = world, interp = interp)
 end
 
 @doc(
 """
-    code_inferred(@nospecialize(f), t::Type...; 
+    code_inferred(@nospecialize(f), t::Type...;
             world = Base.get_world_counter(),
             interp = Core.Compiler.NativeInterpreter(world))
 

--- a/test/builder.jl
+++ b/test/builder.jl
@@ -144,4 +144,3 @@ end
     display(finish(p))
     println()
 end
-

--- a/test/canvas.jl
+++ b/test/canvas.jl
@@ -71,15 +71,15 @@ end
     pushfirst!(c, Expr(:call, +, 15, 15))
     pushfirst!(c, Expr(:call, +, 20, 20))
     pushfirst!(c, Expr(:call, +, 25, 25))
-    
+
     @test unwrap(getindex(c, 1)) == Expr(:call, +, 5, 5)
     setindex!(c, Expr(:call, *, 10, 10), 1)
     @test unwrap(getindex(c, 1)) == Expr(:call, *, 10, 10)
-    
+
     @test unwrap(getindex(c, 2)) == Expr(:call, +, 10, 10)
     setindex!(c, Expr(:call, *, 5, 5), 2)
     @test unwrap(getindex(c, 2)) == Expr(:call, *, 5, 5)
-    
+
     @test unwrap(getindex(c, 3)) == Expr(:call, +, 15, 15)
     setindex!(c, Expr(:call, *, 10, 10), 3)
     @test unwrap(getindex(c, 3)) == Expr(:call, *, 10, 10)

--- a/test/evaluation.jl
+++ b/test/evaluation.jl
@@ -48,7 +48,7 @@ end
 rosenbrock(x, y, a, b) = (a - x)^2 + b * (y - x^2)^2
 
 @testset "Evaluation with nargs - slots = (#self, :x, :y, :a, :b)" begin
-    b = Builder(code_info(rosenbrock, Float64, Float64, 
+    b = Builder(code_info(rosenbrock, Float64, Float64,
                           Float64, Float64))
     identity(b)
     fn = λ(finish(b), 4)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -9,7 +9,7 @@ end
 
 @testset "`walk` -- misc." begin
     v = Core.NewvarNode(Core.SlotNumber(5))
-    walk(x -> x isa Core.SlotNumber ? 
+    walk(x -> x isa Core.SlotNumber ?
          Core.SlotNumber(x.id + 1) : x, v)
 end
 


### PR DESCRIPTION
I found there are many trailing whitespaces in the source files, this is a little bit annoying when I edit and save one of them then find many lines are changed because the editor removes these no meaning spaces automatically, hope we can remove them.