### PR TITLE
Julia 1.11: add ssaflags to Canvas

### DIFF
--- a/test/canvas.jl
+++ b/test/canvas.jl
@@ -13,6 +13,7 @@
     for i in 1 : 5
         @test c.defs[i] == (i, i)
         @test c.codelocs[i] == Int32(1)
+        @test c.ssaflags[i] == UInt32(0)
         @test unwrap(getindex(c, i)) == Expr(:call, rand)
     end
 end


### PR DESCRIPTION
I had to do this to make things work on the latest Julia nightly. Otherwise the ssaflags vector didn't have the correct length and a getindex error was thrown.
I don't really know what change in Julia caused the need for this, or if this is a completely correct solution, but it works.